### PR TITLE
fix: use `ibc::types::ConsensusState` and `ConsensusStateDerive` for conversions to satisfy bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ cosmwasm-std = { version = "1.5.0", features = [
 cw-storage-plus = "1.1.0"
 cw2 = "1.1.1"
 derive_more = "0.99.17"
-ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "3b11b12cc7963f8391a547bd2d60744708e91cbd", default-features = false } # "0.50.0"
+ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "3b11b12cc7963f8391a547bd2d60744708e91cbd", default-features = false, features = ["schema"] } # "0.50.0"
 ibc-proto = { git = "https://github.com/cosmos/ibc-proto-rs.git", rev = "3adf964d795bf4d53150f3b2ce47feed93121759", default-features = false } # "0.42.0"
 prost = "0.12.3"
 schemars = "0.8.15"

--- a/src/context/ctx.rs
+++ b/src/context/ctx.rs
@@ -3,10 +3,10 @@ use ibc::core::client::context::ClientExecutionContext;
 use ibc::core::client::types::error::ClientError;
 
 use ibc::core::client::context::ClientValidationContext;
-use ibc::core::host::types::identifiers::ClientId;
-use ibc::core::primitives::Timestamp;
 use ibc::core::client::types::Height;
 use ibc::core::handler::types::error::ContextError;
+use ibc::core::host::types::identifiers::ClientId;
+use ibc::core::primitives::Timestamp;
 
 /// Enables conversion (`TryInto` and `From`) between the consensus state type
 /// used by the host and the one specific to the Rollkit light client, which

--- a/src/context/custom_ctx.rs
+++ b/src/context/custom_ctx.rs
@@ -12,10 +12,10 @@ use ibc::core::host::types::path::{
 };
 use ibc::core::primitives::proto::{Any, Protobuf};
 
-use prost::Message;
-
+use crate::types::AnyCodec;
 use crate::types::ClientType;
 use crate::{parse_height, ContractError, GenesisMetadata, HeightTravel};
+use prost::Message;
 
 type Checksum = Vec<u8>;
 

--- a/src/context/execution_ctx.rs
+++ b/src/context/execution_ctx.rs
@@ -7,6 +7,7 @@ use ibc::core::host::types::path::{iteration_key, ClientConsensusStatePath, Clie
 use ibc::core::primitives::Timestamp;
 
 use super::Context;
+use crate::types::AnyCodec;
 use crate::types::ClientType;
 
 impl<'a, C: ClientType<'a>> ClientExecutionContext for Context<'a, C> {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,4 +1,4 @@
-mod ctx;
+// mod ctx;
 mod custom_ctx;
 mod execution_ctx;
 mod validation_ctx;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -6,10 +6,10 @@ use prost::Message;
 
 use crate::context::Context;
 use crate::types::{
-    CheckForMisbehaviourMsg, ContractError, ContractResult, ExportMetadataMsg, InstantiateMsg,
-    QueryMsg, QueryResponse, StatusMsg, SudoMsg, UpdateStateMsg, UpdateStateOnMisbehaviourMsg,
-    VerifyClientMessageMsg, VerifyMembershipMsg, VerifyNonMembershipMsg,
-    VerifyUpgradeAndUpdateStateMsg, ClientMessage,
+    CheckForMisbehaviourMsg, ClientMessage, ContractError, ContractResult, ExportMetadataMsg,
+    InstantiateMsg, QueryMsg, QueryResponse, StatusMsg, SudoMsg, UpdateStateMsg,
+    UpdateStateOnMisbehaviourMsg, VerifyClientMessageMsg, VerifyMembershipMsg,
+    VerifyNonMembershipMsg, VerifyUpgradeAndUpdateStateMsg,
 };
 
 impl<'a, C: ClientType<'a>> Context<'a, C> {

--- a/src/types/client_type.rs
+++ b/src/types/client_type.rs
@@ -1,4 +1,4 @@
-use ibc::clients::tendermint::types::ClientState as TendermintClientState;
+use ibc::clients::tendermint::client_state::ClientState as TendermintClientState;
 use ibc::core::client::context::client_state::ClientStateExecution;
 use ibc::core::client::context::consensus_state::ConsensusState as ConsensusStateTrait;
 use ibc::core::client::types::error::ClientError;

--- a/src/types/codec.rs
+++ b/src/types/codec.rs
@@ -1,5 +1,4 @@
-use ibc::core::client::types::error::ClientError;
-use ibc_proto::google::protobuf::Any;
+use ibc::{core::client::types::error::ClientError, primitives::proto::Any};
 use prost::Message;
 
 pub trait AnyCodec {

--- a/src/types/consensus_state.rs
+++ b/src/types/consensus_state.rs
@@ -1,21 +1,21 @@
 use ibc::clients::tendermint::consensus_state::ConsensusState as TendermintConsensusState;
-use ibc::clients::tendermint::types::TENDERMINT_CONSENSUS_STATE_TYPE_URL;
+use ibc::clients::tendermint::types::{ConsensusState, TENDERMINT_CONSENSUS_STATE_TYPE_URL};
 use ibc::core::client::types::error::ClientError;
-//use ibc::core::derive::ConsensusState as ConsensusStateDerive;
 use ibc::core::primitives::proto::Any;
+use ibc::derive::ConsensusState as ConsensusStateDerive;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ConsensusStateDerive)]
 pub enum AnyConsensusState {
     Rollkit(TendermintConsensusState),
 }
 
-impl From<TendermintConsensusState> for AnyConsensusState {
-    fn from(value: TendermintConsensusState) -> Self {
+impl From<ConsensusState> for AnyConsensusState {
+    fn from(value: ConsensusState) -> Self {
         AnyConsensusState::Rollkit(value.into())
     }
 }
 
-impl TryFrom<AnyConsensusState> for TendermintConsensusState {
+impl TryFrom<AnyConsensusState> for ConsensusState {
     type Error = ClientError;
 
     fn try_from(value: AnyConsensusState) -> Result<Self, Self::Error> {


### PR DESCRIPTION
## Remark

Commented out the custom trait definitions in the `ctx.rs` file. Since we're utilizing the Tendermint ClientState implementation from ibc-rs, we should import the required custom `ValidationContext` from ibc-rs as well.